### PR TITLE
Fixed file format

### DIFF
--- a/cutout/src/main/java/com/github/gabrielbb/cutout/SaveDrawingTask.java
+++ b/cutout/src/main/java/com/github/gabrielbb/cutout/SaveDrawingTask.java
@@ -18,7 +18,7 @@ import static android.view.View.VISIBLE;
 
 class SaveDrawingTask extends AsyncTask<Bitmap, Void, Pair<File, Exception>> {
 
-    private static final String SAVED_IMAGE_FORMAT = "png";
+    private static final String SAVED_IMAGE_FORMAT = ".png";
     private static final String SAVED_IMAGE_NAME = "cutout_tmp";
 
     private final WeakReference<CutOutActivity> activityWeakReference;


### PR DESCRIPTION
Added a missing dot to the file format string. Previously the app was caching the image without any format and appended "png" to the filename instead